### PR TITLE
remove name duplicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ name: markdown-link-check
 on:
   push:
 
-name: Check markdown files for broken links
 jobs:
   markdown-link-check:
     name: Check markdown files


### PR DESCRIPTION
There was a duplicate in the `name` field in the basic GitHub Action example:

```yml
name: markdown-link-check

on:
  push:

name: Check markdown files for broken links
```
This was bringing up an error when running the action. I removed the second `name` field.