### PR TITLE
fix: update GitHub Actions permissions in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,14 +10,14 @@ on:
     branches:
       - main
 
-permissions: read-all
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   release-please-pr:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c # v4.3.0
         with:
@@ -26,8 +26,6 @@ jobs:
 
   release-please-release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c # v4.3.0
         id: release


### PR DESCRIPTION
- Adjust permissions for the release-please workflow to enhance access control
- Consolidate permissions under a single key for clarity